### PR TITLE
fix(custom-provider): prevent fetch-external-configs.sh from executing when not needed

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -6,7 +6,7 @@ pull_request_rules:
     conditions:
       - base=main
       - author~=^dependabot(|-preview)\[bot\]$
-      - title~=Bump [^\s]+ from ([\d]+)\..+ to \1\.
+      - check-success=build-scan
       - -conflict
       - label=automerge
     actions:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,11 +14,11 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - openvpn_data:/etc/openvpn
     environment:
-      - OPENVPN_USERNAME=username
-      - OPENVPN_PASSWORD=password
-      - OPENVPN_PROVIDER=vpnprovider
+      - OPENVPN_USERNAME=
+      - OPENVPN_PASSWORD=
+      - OPENVPN_PROVIDER=
       - OPENVPN_OPTS=--user abc --group abc --auth-nocache --inactive 3600 --ping 10 --ping-exit 60
-      - OPENVPN_CONFIG=config_without_ovpn_extension
+      - OPENVPN_CONFIG=
       - LOCAL_NETWORK=192.168.0.0/16
       - CREATE_TUN_DEVICE=true
       - ENABLE_UFW=false

--- a/openvpn.env
+++ b/openvpn.env
@@ -1,8 +1,8 @@
-OPENVPN_USERNAME=username
-OPENVPN_PASSWORD=password
-OPENVPN_PROVIDER=vpnprovider
+OPENVPN_USERNAME=
+OPENVPN_PASSWORD=
+OPENVPN_PROVIDER=
 OPENVPN_OPTS=--user abc --group abc --auth-nocache --inactive 3600 --ping 10 --ping-exit 60 --resolv-retry 15 --mute-replay-warnings
-OPENVPN_CONFIG=your_config_without_ovpn
+OPENVPN_CONFIG=
 LOCAL_NETWORK=192.168.0.0/16
 CREATE_TUN_DEVICE=true
 ENABLE_UFW=false


### PR DESCRIPTION
- Prevent fetch-external-configs.sh from executing when using a custom provider
- Prevent fetch-external-configs.sh from executing if VPN_PROVIDER_HOME already has ovpn files
- Updated variables/files related to OPENVPN_USERNAME, OPENVPN_PASSWORD, OPENVPN_PROVIDER to empty values. This should help to fail properly if you don't provide them.
- minor code clean up
- restrict permissions further on vpncreds if using env variables
- mergify - replace title for check-success condition